### PR TITLE
WIP: motor defs abstraction

### DIFF
--- a/ST_cmd_functions.ino
+++ b/ST_cmd_functions.ino
@@ -25,17 +25,17 @@
 // H              - Help
 
 // Function for moving to a given EL
-void cmd_moveToEL(String wantedEL){
+void cmd_moveToEL(String wantedEL) {
   int ELasInt = wantedEL.toInt();
 
-  if(ELasInt <= 90){
-    if(ELasInt < pub_EL){             // EL Down    / AZ CCW
-      while(ELasInt != pub_EL ){
+  if (ELasInt <= 90) {
+    if (ELasInt < pub_EL) {             // EL Down    / AZ CCW
+      while (ELasInt != pub_EL ) {
         moveStepperOneDeg(setup_EL_PulPin, setup_EL_DirPin, false);
         pub_EL--;
       } 
     } else {
-      while(ELasInt != pub_EL ){      // EL Up      / AZ CW
+      while (ELasInt != pub_EL ) {      // EL Up      / AZ CW
         moveStepperOneDeg(setup_EL_PulPin, setup_EL_DirPin, true);
         pub_EL++;
       }
@@ -48,26 +48,24 @@ void cmd_moveToEL(String wantedEL){
 }
 
 // Function for moving to a given AZ
-void cmd_moveToAZ(String wantedAZ){
+void cmd_moveToAZ(String wantedAZ) {
   int AZasInt = wantedAZ.toInt();
 
   // when AZ at 359° and 0 / 1 is wanted don't go around
-  if(pub_AZ == 359 && AZasInt == 0){
+  if (pub_AZ == 359 && AZasInt == 0) {
     moveStepperOneDeg(setup_AZ_PulPin, setup_AZ_DirPin, true);
     pub_AZ = 0;
-  } else
-  if(pub_AZ == 0 && AZasInt == 359){
+  } else if (pub_AZ == 0 && AZasInt == 359) {
     moveStepperOneDeg(setup_AZ_PulPin, setup_AZ_DirPin, false);
     pub_AZ = 359;
-  } else
-  if(AZasInt <= 359){
-    if(AZasInt < pub_AZ){             // AZ CCW
-      while(AZasInt != pub_AZ ){
+  } else if (AZasInt <= 359) {
+    if (AZasInt < pub_AZ) {             // AZ CCW
+      while (AZasInt != pub_AZ ) {
         moveStepperOneDeg(setup_AZ_PulPin, setup_AZ_DirPin, false);
         pub_AZ--;
       } 
     } else {
-      while(AZasInt != pub_AZ ){      // AZ CW
+      while (AZasInt != pub_AZ ) {      // AZ CW
         moveStepperOneDeg(setup_AZ_PulPin, setup_AZ_DirPin, true);
         pub_AZ++;
       }
@@ -79,26 +77,26 @@ void cmd_moveToAZ(String wantedAZ){
 }
 
 // Function to stop the EL axis
-void cmd_stopEL(){
+void cmd_stopEL() {
   pub_stopEL = true;
 }
 
 // Function to stop the AZ axis
-void cmd_stopAZ(){
+void cmd_stopAZ() {
   pub_stopAZ = true;
 }
 
 // Function to zero out the EL axis
-void cmd_Offset_cal_EL(){
-  if(digitalRead(setup_EL_endstop) == HIGH){
+void cmd_Offset_cal_EL() {
+  if (digitalRead(setup_EL_endstop) == HIGH) {
     // go up until out of Endstop (1°)
-    while(digitalRead(setup_EL_endstop) == HIGH){
+    while (digitalRead(setup_EL_endstop) == HIGH) {
       moveStepperOneDeg(setup_EL_PulPin, setup_EL_DirPin, true);
     }
     moveStepperOneDeg(setup_EL_PulPin, setup_EL_DirPin, false);
   } else {
     // go back until Endstop (0°)
-    while(digitalRead(setup_EL_endstop) == LOW){
+    while (digitalRead(setup_EL_endstop) == LOW) {
       moveStepperOneDeg(setup_EL_PulPin, setup_EL_DirPin, false);
     }
   }
@@ -107,16 +105,16 @@ void cmd_Offset_cal_EL(){
 }
 
 // Function to zero out the AZ axis
-void cmd_Offset_cal_AZ(){
-  if(digitalRead(setup_AZ_endstop) == HIGH){
+void cmd_Offset_cal_AZ() {
+  if (digitalRead(setup_AZ_endstop) == HIGH) {
     // go up until out of Endstop (1°)
-    while(digitalRead(setup_AZ_endstop) == HIGH){
+    while (digitalRead(setup_AZ_endstop) == HIGH) {
       moveStepperOneDeg(setup_AZ_PulPin, setup_AZ_DirPin, true);
     }
     moveStepperOneDeg(setup_AZ_PulPin, setup_AZ_DirPin, false);
   } else {
     // go back until Endstop (0°)
-    while(digitalRead(setup_AZ_endstop) == LOW){
+    while (digitalRead(setup_AZ_endstop) == LOW) {
       moveStepperOneDeg(setup_AZ_PulPin, setup_AZ_DirPin, false);
     }
   }
@@ -125,18 +123,18 @@ void cmd_Offset_cal_AZ(){
 }
 
 
-// FUll calibration to get STepps per 360°
+// FUll calibration to get steps per 360°
 // Function to calibrate the trackers EL axis
-void cmd_calibrateEL(){
+void cmd_calibrateEL() {
   int deg = 0;
   unsigned long allSteps;
   
   Serial.println("Calibrating EL 360° ...");
   
-  if(digitalRead(setup_EL_endstop) == HIGH){
+  if (digitalRead(setup_EL_endstop) == HIGH) {
     Serial.println("Clearing Endstop...");
     // 20° up to clear endstop if in it
-    while(deg <= 20){
+    while (deg <= 20) {
       moveStepperOneDeg(setup_EL_PulPin, setup_EL_DirPin, true);
       deg++;
     }
@@ -144,7 +142,7 @@ void cmd_calibrateEL(){
 
   Serial.println("Going back until hitting the Endstop....");
   // move back until endstop
-  while(digitalRead(setup_EL_endstop) == LOW){
+  while (digitalRead(setup_EL_endstop) == LOW) {
     moveStepperOneDeg(setup_EL_PulPin, setup_EL_DirPin, false);
   }
 
@@ -152,34 +150,34 @@ void cmd_calibrateEL(){
   // move up until at endstop again (around)
   // 20° up to clear endstop if in it
   deg = 0;
-  while(deg <= 20){
+  while (deg <= 20) {
     moveStepperOneDeg(setup_EL_PulPin, setup_EL_DirPin, true);
     allSteps = allSteps + 213;
     deg++;
   }
+
   Serial.println(allSteps);
-  while(digitalRead(setup_EL_endstop) == LOW){
+
+  while (digitalRead(setup_EL_endstop) == LOW) {
     moveStepperOneStep(setup_EL_PulPin, setup_EL_DirPin, true);
     allSteps++;
   }
+
   Serial.println(allSteps);
   Serial.println("At Endstop...moving to the end of the Endstop...");
 
   // turn until at end of Endstop to get 360 degrees
-  while(digitalRead(setup_EL_endstop) == HIGH){
+  while (digitalRead(setup_EL_endstop) == HIGH) {
     moveStepperOneStep(setup_EL_PulPin, setup_EL_DirPin, true);
     allSteps++;
   }
 
-
-  // Report stepps needed
-  Serial.print("Stepps for 360° on EL: ");
+  // Report steps needed
+  Serial.print("Steps for 360° on EL: ");
   Serial.println(allSteps);
 }
 
 // Function to calibrate the trackers AZ axis
-void cmd_calibrateAZ(){
-  
+void cmd_calibrateAZ() {
+  // noop
 }
-
-

--- a/SatTracker.ino
+++ b/SatTracker.ino
@@ -30,34 +30,34 @@
 
 
 //----- SETUP -----
-//#define setup_EL_steps 76800              // Steps for 360 degrees on the Elevation axis
-//#define setup_AZ_steps 76800              // Steps for 360 degrees on the Azimuth axis
-#define setup_steps 86000                   // Steps for 360 degrees on both axis
+#include "StepperMotorDefinitions.ino"
 
-#define setup_EL_endstop 3                  // Endstop Signal EL
-#define setup_AZ_endstop 4                  // Endstop Signal AZ
+#define setup_EL_endstop 3      // Endstop Signal EL
+#define setup_AZ_endstop 4      // Endstop Signal AZ
 
-#define setup_EnaStepper 2                  // Enable Steppers (off = Steppers enabled)
+#define setup_EnaStepper 2      // Enable Steppers (off = Steppers enabled)
 // Pins Stepper EL
-#define setup_EL_PulPin 6                   // Pulse pin
-#define setup_EL_DirPin 7                   // Direction pin
+#define setup_EL_PulPin 6       // Pulse pin
+#define setup_EL_DirPin 7       // Direction pin
 // Pins Stepper AZ
-#define setup_AZ_PulPin 8                   // Pulse pin
-#define setup_AZ_DirPin 9                   // Direction pin
+#define setup_AZ_PulPin 8       // Pulse pin
+#define setup_AZ_DirPin 9       // Direction pin
 
+#define SERIAL_BAUD 115200
+#define SERIAL_TIMEOUT 50
 //----- Start of Programm -----
 String serialIn;
 
-// PUBlic variables
-int pub_EL = 0;                     // Elevation angle
-int pub_AZ = 0;                     // Azimuth angle
-boolean pub_stopEL = false;         // Stop flag for EL
-boolean pub_stopAZ = false;         // Stop flag for az
-int pub_stepDelay = 300;           // delay between steps in microseconds / Set by speed commands
+// Public variables
+int pub_EL = 0;                 // Elevation angle
+int pub_AZ = 0;                 // Azimuth angle
+bool pub_stopEL = false;        // Stop flag for EL
+bool pub_stopAZ = false;        // Stop flag for az
+int pub_stepDelay = 300;        // delay between steps in microseconds / Set by speed commands
 
 void setup() {
-  Serial.begin(115200);
-  Serial.setTimeout(50);
+  Serial.begin(SERIAL_BAUD);
+  Serial.setTimeout(SERIAL_TIMEOUT);
 
   pinMode(setup_EnaStepper, OUTPUT);
 
@@ -71,114 +71,108 @@ void setup() {
   pinMode(setup_AZ_endstop, INPUT);
 
   pinMode(LED_BUILTIN, OUTPUT);
-
 }
 
 void loop() {
-
-// Check if there i something new on Serial
-  if(Serial.available() > 0){
+  // Check if there i something new on Serial
+  if (Serial.available() > 0) {
 
     serialIn = Serial.readString();
 
-     digitalWrite(LED_BUILTIN, HIGH);   // turn the LED on (HIGH is the voltage level)
-     delay(500);                        // wait for a second
-     digitalWrite(LED_BUILTIN, LOW);    // turn the LED off by making the voltage LOW             
-    
+    digitalWrite(LED_BUILTIN, HIGH);   // turn the LED on (HIGH is the voltage level)
+    delay(500);                        // wait for half a second
+    digitalWrite(LED_BUILTIN, LOW);    // turn the LED off by making the voltage LOW
 
     // There is, so let's see if it is a valid cmd
-    if (serialIn == "B"){                                 // Report elevation (el)
+    if (serialIn == "B") {                         // Report elevation (el)
       Serial.print("EL=");
       Serial.println(pub_EL);
-    } else if(serialIn == "C"){                           // Report azimuth (az)
+    } else if(serialIn == "C") {                   // Report azimuth (az)
       Serial.print("AZ=");
       Serial.println(pub_AZ);
-    } else if(serialIn == "C2"){                          // Report az and el
+    } else if(serialIn == "C2") {                  // Report az and el
       Serial.print("AZ=");
       Serial.print(pub_AZ);
       Serial.print(" EL=");
       Serial.println(pub_EL);
-    } else if(serialIn == "S"){                           // Stop all rotation
+    } else if(serialIn == "S") {                   // Stop all rotation
       cmd_stopEL();
       cmd_stopAZ();
-    } else if(serialIn == "A"){                           // Stop az rotation
+    } else if(serialIn == "A") {                   // Stop az rotation
       cmd_stopAZ();
-    } else if(serialIn == "E"){                           // Stop el rotation
+    } else if(serialIn == "E") {                   // Stop el rotation
       cmd_stopEL();
-    } else if(serialIn == "L"){                           // rotate azimuth left (CCW)
-      
-    } else if(serialIn == "R"){                           // rotate azimuth right (CW)
-      
-    } else if(serialIn == "D"){                           // rotate elevation down
-      
-    } else if(serialIn == "U"){                           // rotate elevation up
-      
-    } else if(serialIn.substring(0, 1) == "M"){           // Move to azimuth
+    } else if(serialIn == "L") {                   // rotate azimuth left (CCW)
+      // noop
+    } else if(serialIn == "R") {                   // rotate azimuth right (CW)
+      // noop
+    } else if(serialIn == "D") {                   // rotate elevation down
+      // noop
+    } else if(serialIn == "U") {                   // rotate elevation up
+      // noop
+    } else if(serialIn.substring(0, 1) == "M") {   // Move to azimuth
       cmd_moveToAZ(serialIn.substring(1, 4));
-    } else if(serialIn.substring(0, 1) == "W"){           // Move to azimuth and elevation
+    } else if(serialIn.substring(0, 1) == "W") {   // Move to azimuth and elevation
       cmd_moveToAZ(serialIn.substring(1, 4));
       cmd_moveToEL(serialIn.substring(5, 8));
-    } else if(serialIn == "X1"){                          // Azimuth rotation speed 1
+    } else if(serialIn == "X1") {                  // Azimuth rotation speed 1
       pub_stepDelay = 2000;
-    } else if(serialIn == "X2"){                          // Azimuth rotation speed 2
+    } else if(serialIn == "X2") {                  // Azimuth rotation speed 2
       pub_stepDelay = 1000;
-    } else if(serialIn == "X3"){                          // Azimuth rotation speed 3
+    } else if(serialIn == "X3") {                  // Azimuth rotation speed 3
       pub_stepDelay = 500;
-    } else if(serialIn == "X4"){                          // Azimuth rotation speed 4
+    } else if(serialIn == "X4") {                  // Azimuth rotation speed 4
       pub_stepDelay = 300;
-    } else if(serialIn == "O"){                           // Azimuth offset calibration
+    } else if(serialIn == "O") {                   // Azimuth offset calibration
       cmd_Offset_cal_AZ();
-    } else if(serialIn == "F"){                           // Azimuth full scale calibration
-      
-    } else if(serialIn == "O2"){                          // Elevation offset calibration
+    } else if(serialIn == "F") {                   // Azimuth full scale calibration
+      // noop
+    } else if(serialIn == "O2") {                  // Elevation offset calibration
       cmd_Offset_cal_EL();
-    } else if(serialIn == "F2"){                          // Elevation full scale calibration
+    } else if(serialIn == "F2") {                  // Elevation full scale calibration
       // cmd_calibrateEL();
-    } else if(serialIn == "P36"){                         // Switch to 360 degree mode
-      
-    } else if(serialIn == "P45"){                         // Switch to 450 degree mode
-      
-    } else if(serialIn == "Z"){                           // Toggle north/South centered mode
-      
-    } else if(serialIn == "H"){                           // Help
-      
+    } else if(serialIn == "P36") {                 // Switch to 360 degree mode
+      // noop
+    } else if(serialIn == "P45") {                 // Switch to 450 degree mode
+      // noop
+    } else if(serialIn == "Z") {                   // Toggle north/South centered mode
+      // noop
+    } else if(serialIn == "H") {                   // Help
+      // noop
     }
   }
-    
 }
 
-
 // Function to drive a stepper one degree. rev = false = CW rotation
-void moveStepperOneDeg(int PULpin, int DIRpin, boolean rev){
+void moveStepperOneDeg(int PULpin, int DIRpin, bool rev) {
   int i;
   //Serial.println("moving Stepper");
-  if(rev){
+  if (rev) {
     digitalWrite(DIRpin, LOW);
   } else {
     digitalWrite(DIRpin, HIGH);
   }
+
   i = 0;
-  while(i < setup_steps / 360){
+  while (i < setup_steps / 360) {
     digitalWrite(PULpin, HIGH);
     delayMicroseconds(100);
     digitalWrite(PULpin, LOW);
     delayMicroseconds(pub_stepDelay);
     i++;
   }
-  
 }
 
-void moveStepperOneStep(int PULpin, int DIRpin, boolean rev){
-  if(rev){
+void moveStepperOneStep(int PULpin, int DIRpin, bool rev) {
+  if (rev) {
     digitalWrite(DIRpin, LOW);
   } else {
     digitalWrite(DIRpin, HIGH);
   }
 
-  
-    digitalWrite(PULpin, HIGH);
-    delayMicroseconds(100);
-    digitalWrite(PULpin, LOW);
-    delayMicroseconds(pub_stepDelay);
+  digitalWrite(PULpin, HIGH);
+  delayMicroseconds(100);
+  digitalWrite(PULpin, LOW);
+  delayMicroseconds(pub_stepDelay);
 }
 

--- a/StepperMotorDefinitions.ino
+++ b/StepperMotorDefinitions.ino
@@ -1,0 +1,45 @@
+// Abstraction of stepper motor definitions.
+//
+// Originally this project was built around NEMA23 steppers, which come in a variety of flavors. This is
+// where I'll start.
+
+#ifndef __STEPPER_MOTOR_DEFS
+  #define __STEPPER_MOTOR_DEFS
+
+  #define __T_PULLEY_MOTOR 20
+  #define __T_PULLEY_WORM 40
+
+  #define __T_GEAR_WORM 1 // per the worm's STL file
+  #define __T_GEAR_SPUR 27 // per the spur gear's STL file
+
+  // Supported Motors:
+  //   NEMA23 (Std 1.8deg step): __NEMA23_STD
+  //   NEMA23 (Nonstd 0.9deg step): __NEMA23_09
+  #define __NEMA23_STD
+
+  // TODO: Start adding metrics for various stepper motors
+  #define __STEP_DEGREES 1.8 // arbitrary default
+  #ifdef __NEMA23_STD
+      #undef __STEP_DEGREES
+      #define __STEP_DEGREES 1.8
+  #endif
+
+  #ifdef __NEMA23_09
+      #undef __STEP_DEGREES
+      #define __STEP_DEGREES 0.9
+  #endif
+
+  // Pulley ratio is Tw / Tm
+  #define RATIO_PULLEY_DRIVE __T_PULLEY_WORM / __T_PULLEY_MOTOR
+  // Worm ratio is Ts / Tw
+  #define RATIO_WORM_DRIVE  __T_GEAR_SPUR / __T_GEAR_WORM
+  // Motor steps per full rotation is 360 / step angle
+  #define STEPS_360 360 / __STEP_DEGREES
+
+  //#define setup_EL_steps 76800              // Steps for 360 degrees on the Elevation axis
+  //#define setup_AZ_steps 76800              // Steps for 360 degrees on the Azimuth axis
+
+  // Motor Steps * pulley ratio * worm ratio
+  // #define setup_steps STEPS_360 * RATIO_PULLEY_DRIVE * RATIO_WORM_DRIVE // this doesn't match the 86000 below
+  #define setup_steps 86000                   // Steps for 360 degrees on each axis
+#endif


### PR DESCRIPTION
**Work in Progress PR**

I see there's some calibration methods, but there's also a basic `setup_steps`. I'm giving some definition to that value based on the stepper motor's step angle (`1.8` for most NEMA23 steppers, `0.9` for a few irregular NEMA23's), the drive pulley ratio (`40:20` reduction in the blog's part specs), and the worm drive ratio (`27:1` reduction per the blog's STL files).

**NOTE:** The pulley and worm ratios account for 10,800 steps for a 360 degree turn. I'm still grokking the original definition of 86,000 steps.
